### PR TITLE
Added Redis examples for Go and Python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,17 @@ Python
 - `Write to Redis <redis/python/write.py>`_
 - `Read from Redis <redis/python/read.py>`_
 
+Cassandra
+=========
+Go
+--
+- `Write to Cassandra <cassandra/go/write.go>`_
+- `Read from Cassandra <cassandra/go/read.go>`_
+Python
+------
+- `Write to Cassandra <cassandra/python/write.py>`_
+- `Read from Cassandra <cassandra/python/read.py>`_
+
 License
 =======
 

--- a/cassandra/go/read.go
+++ b/cassandra/go/read.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gocql/gocql"
+)
+
+// *******
+// DISCLAIMER: This code might fail because of "unable to connect to initial hosts: unexpected authenticator"
+// We have an open pull request at github.com/gocql/gocql for them to add the Aiven authenticator to the approved list
+// ********
+
+const (
+	host     = "cassandra-3b8d4ed6-myfirstcloudhub.aivencloud.com"
+	port     = 15193
+	username = "avnadmin"
+	password = "nr0dfnswz36xs9pi"
+)
+
+func main() {
+	cluster := gocql.NewCluster(host)
+	cluster.Port = port
+	cluster.ProtoVersion = 4
+	cluster.Authenticator = gocql.PasswordAuthenticator{
+		Username: username,
+		Password: password,
+	}
+	cluster.SslOpts = &gocql.SslOptions{
+		CaPath: "ca.pem",
+	}
+	cluster.Keyspace = "example_keyspace"
+	cluster.Consistency = gocql.Quorum
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer session.Close()
+	iter := session.Query("SELECT id, message FROM example_table").Iter()
+	var id int
+	var message string
+	for iter.Scan(&id, &message) {
+		fmt.Printf("Row: id = %d, message = %s\n", id, message)
+	}
+}

--- a/cassandra/go/write.go
+++ b/cassandra/go/write.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"log"
+
+	"github.com/gocql/gocql"
+)
+
+const (
+	host     = "cassandra-3b8d4ed6-myfirstcloudhub.aivencloud.com"
+	port     = 15193
+	username = "avnadmin"
+	password = "nr0dfnswz36xs9pi"
+)
+
+// *******
+// DISCLAIMER: This code might fail because of "unable to connect to initial hosts: unexpected authenticator"
+// We have an open pull request at github.com/gocql/gocql for them to add the Aiven authenticator to the approved list
+// ********
+
+// Create a keyspace called 'example_keyspace' before running this
+
+func main() {
+	cluster := gocql.NewCluster(host)
+	cluster.Port = port
+	cluster.ProtoVersion = 4
+	cluster.Authenticator = gocql.PasswordAuthenticator{
+		Username: username,
+		Password: password,
+	}
+	cluster.SslOpts = &gocql.SslOptions{
+		CaPath: "ca.pem",
+	}
+	cluster.Keyspace = "example_keyspace"
+	cluster.Consistency = gocql.Quorum
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer session.Close()
+	if err := session.Query(
+		"CREATE TABLE example_table (id int PRIMARY KEY, message text)",
+	).Exec(); err != nil {
+		log.Print(err)
+	}
+	if err := session.Query(
+		"INSERT INTO example_table (id, message) VALUES (?, ?)", 123, "Hello world!",
+	).Exec(); err != nil {
+		log.Fatal(err)
+	}
+	log.Println("Row inserted")
+}

--- a/cassandra/python/read.py
+++ b/cassandra/python/read.py
@@ -1,0 +1,14 @@
+import ssl
+from cassandra.cluster import Cluster
+from cassandra.auth import PlainTextAuthProvider
+
+host = "cassandra-3b8d4ed6-myfirstcloudhub.aivencloud.com"
+port = 15193
+auth_provider = PlainTextAuthProvider("avnadmin", "nr0dfnswz36xs9pi")
+ssl_options = {"ca_certs": "ca.pem", "cert_reqs": ssl.CERT_REQUIRED}
+
+with Cluster([host], port=port, ssl_options=ssl_options, auth_provider=auth_provider) as cluster:
+    with cluster.connect() as session:
+        session.execute("USE example_keyspace")
+        for row in session.execute("SELECT id, message FROM example_table"):
+            print("Row: id = {}, message = {}".format(row.id, row.message))

--- a/cassandra/python/write.py
+++ b/cassandra/python/write.py
@@ -1,0 +1,24 @@
+import ssl
+from cassandra.cluster import Cluster
+from cassandra.auth import PlainTextAuthProvider
+
+import cassandra
+
+host = "cassandra-3b8d4ed6-myfirstcloudhub.aivencloud.com"
+port = 15193
+auth_provider = PlainTextAuthProvider("avnadmin", "nr0dfnswz36xs9pi")
+ssl_options = {"ca_certs": "ca.pem", "cert_reqs": ssl.CERT_REQUIRED}
+
+with Cluster([host], port=port, ssl_options=ssl_options, auth_provider=auth_provider) as cluster:
+    with cluster.connect() as session:
+        try:
+            session.execute("CREATE KEYSPACE example_keyspace WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'aiven': 3}")
+        except cassandra.AlreadyExists as ex:
+            print(ex)
+        session.execute("USE example_keyspace")
+        try:
+            session.execute("CREATE TABLE example_table (id int PRIMARY KEY, message text)")
+        except cassandra.AlreadyExists as ex:
+            print(ex)
+        session.execute("INSERT INTO example_table (id, message) VALUES (%s, %s)", (123, "Hello world!"))
+        print("Row inserted")


### PR DESCRIPTION
Created basic examples for writing data to Redis, and then querying
previously mentioned data. The go code is dependant on https://github.com/gocql/gocql
accepting the Aiven authentication provider as an approved provider in their code.
PR has been opened.