### PR TITLE
Update go examples

### DIFF
--- a/cassandra/go/README.md
+++ b/cassandra/go/README.md
@@ -17,5 +17,5 @@ go build main.go cassandra_example.go
 #### Running The Example
 Note: You can find the connection details in the "Overview" tab in the Aiven Console.
 ```
-./main --host cassandra-project.aivencloud.com --port <cassandra port> --password <cassandra password> --ca-path <path to ca.pem>
+./main -host cassandra-project.aivencloud.com -port <cassandra port> -password <cassandra password> -ca-path <path to ca.pem>
 ```

--- a/cassandra/go/main.go
+++ b/cassandra/go/main.go
@@ -30,11 +30,11 @@ func parseArgs() Args {
 	flag.Parse()
 
 	if args.Host == "" {
-		fail("--host is required")
+		fail("-host is required")
 	} else if args.Port == -1 {
-		fail("--port is required")
+		fail("-port is required")
 	} else if args.Password == "" {
-		fail("--password is required")
+		fail("-password is required")
 	}
 	return args
 }

--- a/elasticsearch/go/README.md
+++ b/elasticsearch/go/README.md
@@ -16,5 +16,5 @@ go build main.go elasticsearch_example.go
 #### Running The Example
 Note: You can find the connection details in the "Overview" tab in the Aiven Console.
 ```
-./main --url https://<host>:<port> --password <Elasticsearch password>
+./main -url https://<host>:<port> -password <Elasticsearch password>
 ```

--- a/elasticsearch/go/main.go
+++ b/elasticsearch/go/main.go
@@ -25,9 +25,9 @@ func parseArgs() Args {
 	flag.Parse()
 
 	if args.URL == "" {
-		fail("--url is required")
+		fail("-url is required")
 	} else if args.Password == "" {
-		fail("--password is required")
+		fail("-password is required")
 	}
 	return args
 }

--- a/influxdb/go/READEME.md
+++ b/influxdb/go/READEME.md
@@ -17,5 +17,5 @@ go build main.go influxdb_example.go
 #### Running The Example
 Note: You can find the connection details in the "Overview" tab in the Aiven Console.
 ```
-./main --host https://<host>:<port> --password <password>
+./main -host https://<host>:<port> -password <password>
 ```

--- a/influxdb/go/main.go
+++ b/influxdb/go/main.go
@@ -28,9 +28,9 @@ func parseArgs() Args {
 	flag.Parse()
 
 	if args.Host == "" {
-		fail("--host is required")
+		fail("-host is required")
 	} else if args.Password == "" {
-		fail("--password is required")
+		fail("-password is required")
 	}
 	return args
 }

--- a/kafka/go/README.md
+++ b/kafka/go/README.md
@@ -23,9 +23,9 @@ Note: You can find the connection details in the "Overview" tab in the Aiven Con
     ```
 2. Open two shells. In the first, create a consumer:
     ```
-    ./main --service-uri <host>:<port> --ca-path <ca.pem path> --key-path <service.key path>  --cert-path <service.cert path>  --consumer
+    ./main -service-uri <host>:<port> -ca-path <ca.pem path> -key-path <service.key path>  -cert-path <service.cert path>  -consumer
     ```
 3. Once you see the message "Ready to consume messages", execute the producer in the second shell:
     ```
-    ./main --service-uri <host>:<port> --ca-path <ca.pem path> --key-path <service.key path>  --cert-path <service.cert path>  --producer
+    ./main -service-uri <host>:<port> -ca-path <ca.pem path> -key-path <service.key path>  -cert-path <service.cert path>  -producer
     ```

--- a/kafka/go/main.go
+++ b/kafka/go/main.go
@@ -36,17 +36,17 @@ func parseArgs() Args {
 
 	flag.Parse()
 	if args.ServiceURI == "" {
-		fail("--service-uri is required")
+		fail("-service-uri is required")
 	} else if args.CaPath == "" {
-		fail("--ca-path is required")
+		fail("-ca-path is required")
 	} else if args.KeyPath == "" {
-		fail("--key-path is required")
+		fail("-key-path is required")
 	} else if args.CertPath == "" {
-		fail("--cert-path is required")
+		fail("-cert-path is required")
 	} else if args.Consumer && args.Producer {
-		fail("--consumer and --producer are mutually exclusive")
+		fail("-consumer and -producer are mutually exclusive")
 	} else if !args.Consumer && !args.Producer {
-		fail("--producer or --consumer must be specified")
+		fail("-producer or -consumer must be specified")
 	}
 	return args
 }

--- a/postgresql/go/README.md
+++ b/postgresql/go/README.md
@@ -10,5 +10,5 @@ go get github.com/lib/pq
 #### Running The Example
 Note: You can retrieve the Service URI from the Aiven Console overview tab.
 ```
-go run main.go --service-uri postgres://<user>:<password>@<host>:<port>/<database>?<options>
+go run main.go -service-uri postgres://<user>:<password>@<host>:<port>/<database>?<options>
 ```

--- a/postgresql/go/main.go
+++ b/postgresql/go/main.go
@@ -15,7 +15,7 @@ func main() {
 	flag.Parse()
 	if *serviceURI == "" {
 		flag.Usage()
-		log.Fatal("--service-uri is required")
+		log.Fatal("-service-uri is required")
 	}
 
 	// Connect to Postgres DB

--- a/redis/go/README.md
+++ b/redis/go/README.md
@@ -17,5 +17,5 @@ go build main.go redis_example.go
 #### Running The Example
 Note: You can retrieve the connection details from the Aiven Console overview tab.
 ```
-./main --host <redis host> --password <redis password> --port <redis port>
+./main -host <redis host> -password <redis password> -port <redis port>
 ```

--- a/redis/go/main.go
+++ b/redis/go/main.go
@@ -20,17 +20,17 @@ func main() {
 
 func parseArgs() Args {
 	var args Args
-	flag.StringVar(&args.Host, "host", "", "Cassandra host")
-	flag.IntVar(&args.Port, "port", -1, "Cassandra port")
-	flag.StringVar(&args.Password, "password", "", "Cassandra password")
+	flag.StringVar(&args.Host, "host", "", "Redis host")
+	flag.IntVar(&args.Port, "port", -1, "Redis port")
+	flag.StringVar(&args.Password, "password", "", "Redis password")
 	flag.Parse()
 
 	if args.Host == "" {
-		fail("--host is required")
+		fail("-host is required")
 	} else if args.Port == -1 {
-		fail("--port is required")
+		fail("-port is required")
 	} else if args.Password == "" {
-		fail("--password is required")
+		fail("-password is required")
 	}
 	return args
 }

--- a/tests/test_aiven_examples.py
+++ b/tests/test_aiven_examples.py
@@ -40,7 +40,7 @@ class PostgresTest(AivenExampleTest):
         self.verify_postgres_example(command)
 
     def test_go_example(self):
-        command = f"go run postgresql/go/main.go --service-uri {self.service_uri()}"
+        command = f"go run postgresql/go/main.go -service-uri {self.service_uri()}"
         self.verify_postgres_example(command)
 
     def verify_postgres_example(self, command):
@@ -64,7 +64,7 @@ class CassandraTest(AivenExampleTest):
 
     def test_go_example(self):
         go_files = " ".join(glob.glob('cassandra/go/*.go'))
-        command = f"go run {go_files}" + " --host {host} --port {port} --password {password} --ca-path {ca_path}"
+        command = f"go run {go_files}" + " -host {host} -port {port} -password {password} -ca-path {ca_path}"
         result = self.execute(command.format(**self.test_params), check=True)
         assert "Hello from golang!" in result.stdout
 
@@ -104,7 +104,7 @@ class ElasticsearchTest(AivenExampleTest):
         params = self.services["elasticsearch"]["elasticsearch-latest-hobbyist"]["service_uri_params"]
         host, port, password = params["host"], params["port"], params["password"]
         go_files = " ".join(glob.glob('elasticsearch/go/*.go'))
-        result = self.execute(f"go run {go_files} --url https://{host}:{port} --password {password}", check=True)
+        result = self.execute(f"go run {go_files} -url https://{host}:{port} -password {password}", check=True)
         result_json = json.loads(result.stdout)
         assert result_json['name'] == 'John'
         assert result_json['birth_year'] == 1980
@@ -127,7 +127,7 @@ class InfluxDBTest(AivenExampleTest):
         params = self.services['influxdb']['influxdb-latest-hobbyist']["service_uri_params"]
         host, port, password = params["host"], params["port"], params["password"]
         go_files = " ".join(glob.glob('influxdb/go/*.go'))
-        result = self.execute(f"go run {go_files} --host https://{host}:{port} --password {password}", check=True)
+        result = self.execute(f"go run {go_files} -host https://{host}:{port} -password {password}", check=True)
         assert "cpu_load_short map" in result.stdout
         assert "[time value]" in result.stdout
 
@@ -244,7 +244,7 @@ class RedisTest(AivenExampleTest):
         host, port, password = params['host'], params['port'], params['password']
         go_files = " ".join(glob.glob('redis/go/*.go'))
         expected = "The value for 'goRedisExample' is: 'golang'\n"
-        self.verify_redis_example(f"go run {go_files} --host {host} --port {port} --password {password}",
+        self.verify_redis_example(f"go run {go_files} -host {host} -port {port} -password {password}",
                                   expected=expected)
 
     def test_nodejs_example(self):


### PR DESCRIPTION
The golang flag-package, which is used to parse command-line arguments, only supports the specification of flags with a single dash.  This means that arguments must be specified like so:

      $ program -host=example.com -port=80

Rather than the more familiar getopt syntax which would allow `--host xx, --port NN`.

This pull-request updates the output of the golang examples to show the correct usage, and updates the `README.md` files to match.

