### PR TITLE
m3: basic python example

### DIFF
--- a/m3/python/README.md
+++ b/m3/python/README.md
@@ -1,0 +1,16 @@
+### M3DB Python Example
+
+This example uses the [influxdb](https://github.com/influxdata/influxdb-python) library to connect to M3DB and write some data points.
+
+#### Installing Dependencies
+
+```
+pip install influxdb
+```
+
+#### Running The Example
+Note: You can find the connection details in the "Overview" tab in the Aiven Console.
+
+```
+./main.py --host <host> --port <port> --user <user> --password <password>
+```

--- a/m3/python/main.py
+++ b/m3/python/main.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+
+import argparse
+from datetime import datetime
+import json
+import os
+import time
+import logging
+
+import requests
+
+from aiven.client import AivenClient
+from aiven.client.client import Error as AivenClientError
+from influxdb import InfluxDBClient
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", help="M3 Service Host", required=True)
+    parser.add_argument("--port", type=int, help="M3 Service Port", required=True)
+    parser.add_argument("--user", help="M3 Service User", default="avnadmin")
+    parser.add_argument("--password", help="M3 Service Password", required=True)
+    parser.add_argument("--project", help="Aiven Project Name", default=os.environ.get("AIVEN_TEST_PROJECT", "test"))
+    parser.add_argument("--m3db", help="M3DB Service Name", default="m3db-latest-business-8")
+    parser.add_argument("--m3aggregator", help="M3 Aggregator Service Name", default="m3aggregator-latest-business-8")
+
+    args = parser.parse_args()
+
+    client = AivenClient(base_url=os.environ.get("AIVEN_WEB_URL", "https://api.aiven.io"))
+    client.set_auth_token(os.environ["AIVEN_AUTH_TOKEN"])
+
+    log = logging.getLogger(__name__)
+
+    def create_integration(*, source, destination, integration):
+        try:
+            log.info(f"Creating {integration} integration from {source} to {destination}")
+            client.create_service_integration(
+                dest_service=destination,
+                integration_type=integration,
+                project=args.project,
+                source_service=source,
+            )
+        except AivenClientError as ex:
+            message = ex.response.json()["message"]
+            log.warn(f"Error creating {integration} integration from {source} to {destination}")
+            if not (ex.status == 409 and message == "Service integration already exists"):
+                raise
+
+    create_integration(source=args.m3db, destination=args.m3aggregator, integration="m3aggregator")
+
+    client = InfluxDBClient(host=args.host,
+                            port=args.port,
+                            username=args.user,
+                            password=args.password,
+                            database="default",
+                            ssl=True,
+                            path='/api/v1/influxdb')
+
+    json_body = [
+        {
+            "measurement": "cpu_load_short",
+            "tags": {
+                "host": "testnode",
+            },
+            "time": datetime.now().isoformat(),
+            "fields": {
+                "value": 0.95
+            }
+        }
+    ]
+    print(client.write_points(json_body))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aiven_examples.py
+++ b/tests/test_aiven_examples.py
@@ -275,3 +275,22 @@ class MysqlTest(AivenExampleTest):
         result = self.execute(command)
         assert result.returncode == 0
         assert result.stdout == "{'DATABASE()': 'defaultdb'}\n"
+
+
+class M3Test(AivenExampleTest):
+    supported_cloud_providers = ("aws", "google")
+
+    required_services = (
+        ServiceSpec(type="m3db", version="latest", plan="business-8"),
+        ServiceSpec(type="m3aggregator", version="latest", plan="business-8"),
+    )
+
+    def test_python_example(self):
+        if "m3db" not in self.services:
+            pytest.skip("Cannot test on this cloud")
+
+        params = self.services["m3db"]["m3db-latest-business-8"]["service_uri_params"]
+        host, port, password, user = params["host"], params["port"], params["password"], params["user"]
+        command = f"python m3/python/main.py --host {host} --port {port} --user {user} --password {password}"
+        result = self.execute(command)
+        assert result.stdout == "True\n"


### PR DESCRIPTION
Added basic example using python (uses InfluxDB client so just writing points for now). 

Also updated the test harness slightly to allow specifying a particular set of clouds to run on - that way it won't try to create the services in clouds where a particular service type may not be supported.