### PR TITLE
Add some M3 examples

### DIFF
--- a/m3/go/Makefile
+++ b/m3/go/Makefile
@@ -1,0 +1,11 @@
+all: m3_write m3_query
+
+clean:
+	rm -f m3_write m3_query
+
+m3_write: m3_write.go args.go
+	go build $^
+
+m3_query: m3_query.go args.go
+	go build $^
+

--- a/m3/go/README.md
+++ b/m3/go/README.md
@@ -1,0 +1,45 @@
+### M3DB Go Examples
+
+This directory contains two sample programs for using the M3 database. `m3_write.go` writes
+some test metric data to M3's Prometheus write API, using the prometheus remote golang client.
+`m3_query.go` reads out a range of recent metrics using the query API.
+
+#### Installing Dependencies
+
+```
+go get -u github.com/golang/snappy
+go get -u github.com/gogo/protobuf/gogoproto
+go get -u github.com/m3db/prometheus_remote_client_golang/promremote
+```
+
+### Compiling The Example Programs
+
+```
+go build m3_write.go args.go
+go build m3_query.go args.go
+```
+
+or, if `make` is available, you can just run
+
+```
+make
+```
+
+#### Running The Examples
+
+```
+./m3_write -address https:/<user>:<password>@<host>:<port>/api/v1/prom/remote/write -metric-name my_test_metric
+```
+
+The full URL for the Prometheus write endpoint for `-address` can be found in the Aiven console, in
+tab 'Prometheus (write)' of the service view.
+
+After writing some metric data with m3_write, you can query it from the coordinator
+using the URL in the `M3 Coordinator` tab:
+
+```
+./m3_query -address https://<user>:<password>@<host>:<port> -metric-name my_test_metric
+```
+
+This queries a one hour range of most recent metric data with one minute granularity,
+and prints the JSON response.

--- a/m3/go/args.go
+++ b/m3/go/args.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+package main
+
+import (
+	"flag"
+	"log"
+)
+
+type Args struct {
+	Address    string
+	MetricName string
+}
+
+func parseArgs() Args {
+	var args Args
+	flag.StringVar(&args.Address, "address", "", "M3db address")
+	flag.StringVar(&args.MetricName, "metric-name", "", "Metric name")
+	flag.Parse()
+
+	if args.Address == "" {
+		fail("-address is required")
+	}
+	if args.MetricName == "" {
+		fail("-metric-name is required")
+	}
+	return args
+}
+
+func fail(message string) {
+	flag.Usage()
+	log.Fatal(message)
+}

--- a/m3/go/m3_query.go
+++ b/m3/go/m3_query.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"io/ioutil"
+	"net/http"
+)
+
+func main() {
+	var args = parseArgs()
+	now := time.Now().Unix()
+	// Query metrics from a one hour range
+	queryURL := fmt.Sprintf("%s/api/v1/query_range?query=%s&start=%d&end=%d&step=60",
+		args.Address, args.MetricName, now-3600, now,
+	)
+	resp, err := http.Get(queryURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%s: %s\n", resp.Status, body)
+}

--- a/m3/go/m3_write.go
+++ b/m3/go/m3_write.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/m3db/prometheus_remote_client_golang/promremote"
+)
+
+func main() {
+	var args = parseArgs()
+	cfg := promremote.NewConfig(
+		promremote.WriteURLOption(args.Address),
+		promremote.HTTPClientTimeoutOption(60*time.Second),
+		promremote.UserAgent("aiven-m3-example/0.1"),
+	)
+	client, err := promremote.NewClient(cfg)
+	if err != nil {
+		log.Fatal(fmt.Errorf("unable to construct client: %v", err))
+	}
+	timeSeriesList := []promremote.TimeSeries{
+		{
+			Labels: []promremote.Label{
+				{
+					Name:  "__name__",
+					Value: args.MetricName,
+				},
+			},
+			Datapoint: promremote.Datapoint{
+				Timestamp: time.Now(),
+				Value:     123.0,
+			},
+		},
+	}
+
+	var ctx = context.Background()
+	var writeOpts promremote.WriteOptions
+	result, err := client.WriteTimeSeries(ctx, timeSeriesList, writeOpts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Status code: %d\n", result.StatusCode)
+}


### PR DESCRIPTION
Add simple examples that demostrate how to write metrics to, and query
metrics from, a M3 database using Golang.

The m3_write tool uses the Prometheus write API, and writes metric
data points with values. The m3_query tool reads metric data, using
the /api/v1/query API.