### PR TITLE
Fix readme contributing section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,7 @@ It is meant to be used as the technical content to support the `Aiven's devporta
 Contributing
 ------------
 
-Check the `CONTRIBUTING guide <CONTRIBUTING.rst>`_ for details on how to create content for Aiven Developer. You will find the style guide, pull request process and templates for the various content types there.
-
+Check the `CONTRIBUTING guide <CONTRIBUTING.rst>`_ for details on how to contrbute to this repository.
 Contact
 -------
 Bug reports, patches and own submissions are very welcome, please post them as GitHub issues


### PR DESCRIPTION
It should not refer to devportal, so
this should be removed.

Signed-off-by: laysa.uchoa <laysa.uchoa@aiven.io>

# Update this heading, and describe your changes


