### PR TITLE
Fix templates `About`

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,5 +1,6 @@
 ---
 name: ❓ Ask a question
+about: Got stuck on running or need help? Ask away!
 ---
 
 # What can we help you with?

--- a/.github/ISSUE_TEMPLATE/report.md
+++ b/.github/ISSUE_TEMPLATE/report.md
@@ -1,5 +1,6 @@
 ---
 name: 😱 Something is wrong
+about: Example not working, wrong information? Tell us.
 ---
 
 Which example did you try, and what went wrong?

--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -1,5 +1,6 @@
 ---
 name: 💡 Request an example
+about: Which examples would be helpful to add? Why?
 ---
 
 What would you like to see?


### PR DESCRIPTION
Currently, the templates are not working.
GitHub suggests that:

"There is a problem with this template. About can't be blank."

Therefore, adding the about section in this commit.


