### PR TITLE
Kafka perfbeat

### DIFF
--- a/solutions/kafka-perfbeat/README.md
+++ b/solutions/kafka-perfbeat/README.md
@@ -1,0 +1,20 @@
+# kafka-perfbeat
+
+This is a helper script uses `kafka-producer-perf-test.sh` and `kafka-consumer-perf-test.sh` from Apache Kafka distribution to send metrics to Datadog
+
+## Requirement
+
+- `avn` CLI
+- `jq`
+- 1 Kafka service running on Aiven
+
+
+### 
+
+```bash
+./kafka-perfbeat.sh producer
+```
+
+```bash
+./kafka-perfbeat.sh consumer
+```

--- a/solutions/kafka-perfbeat/README.md
+++ b/solutions/kafka-perfbeat/README.md
@@ -1,15 +1,21 @@
 # kafka-perfbeat
 
-This is a helper script uses `kafka-producer-perf-test.sh` and `kafka-consumer-perf-test.sh` from Apache Kafka distribution to send metrics to Datadog
+This script uses `kafka-producer-perf-test.sh` and `kafka-consumer-perf-test.sh` from Apache Kafka distribution to send producer and consumer metrics to Datadog.
+It creates a topic `kafka.auto_create_topics_enable` with replication factor = (# of nodes - 1) to replicate data to all nodes in the cluster, 
+then produces records with `acks=al` to capture perfmance metrics and detect any issues to in-sync replicas in every other nodes.
 
 ## Requirement
 
+- `../scripts/dd-custom-metric.sh` is requied for sending custom metrics to Datadog
 - `avn` CLI
 - `jq`
-- 1 Kafka service running on Aiven
+- `java`
+- kafka release from [here](https://kafka.apache.org/downloads)
+- 1 Kafka service running on Aiven with `kafka.auto_create_topics_enable` enabled.
 
+## Usage
 
-### 
+Replace corresponding project, service names and set desired values in `kafka-perfbeat.env`
 
 ```bash
 ./kafka-perfbeat.sh producer

--- a/solutions/kafka-perfbeat/kafka-perfbeat.env
+++ b/solutions/kafka-perfbeat/kafka-perfbeat.env
@@ -1,9 +1,10 @@
 export DD_API_KEY="*************************"
 PROJECT="your-project"
-SERVICE_KAFKA="your-kafka"
-REPLICATION=3
+SERVICE_KAFKA="your-service"
 KAFKA_HOME=/opt/kafka
 TOPIC=perfbeat
 MAX_RECORDS=15
 RECORD_SIZE=512
+RETENTION_BYTES=4096
 SLEEP=1
+METRIC_PREFIX="aiven.kafka"

--- a/solutions/kafka-perfbeat/kafka-perfbeat.env
+++ b/solutions/kafka-perfbeat/kafka-perfbeat.env
@@ -1,0 +1,9 @@
+export DD_API_KEY="*************************"
+PROJECT="your-project"
+SERVICE_KAFKA="your-kafka"
+REPLICATION=3
+KAFKA_HOME=/opt/kafka
+TOPIC=perfbeat
+MAX_RECORDS=15
+RECORD_SIZE=512
+SLEEP=1

--- a/solutions/kafka-perfbeat/kafka-perfbeat.sh
+++ b/solutions/kafka-perfbeat/kafka-perfbeat.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+source kafka-perfbeat.env
+
+perfbeat_init() {
+
+    rm -f client.properties client.truststore.jks client.keystore.p12
+#avn service user-creds-download ${SERVICE_KAFKA} --username avnadmin -d .
+    avn service user-kafka-java-creds ${SERVICE_KAFKA} --username avnadmin -d .
+    avn service topic-create ${SERVICE_KAFKA} perfbeat --partitions 1 --replication ${REPLICATION} --retention-bytes 4096
+
+    avn service wait ${SERVICE_KAFKA}
+
+    KAFKA_SERVICE_URI=$(avn service list --json ${SERVICE_KAFKA} | jq -r '.[].service_uri')
+    echo ${KAFKA_SERVICE_URI}
+}
+
+perfbeat_producer() {
+    perfbeat_init
+
+    while [ 1 ];
+    do
+        metrics="$(${KAFKA_HOME}/bin/kafka-producer-perf-test.sh --topic ${TOPIC} --throughput ${MAX_RECORDS} --num-records ${MAX_RECORDS} --record-size ${RECORD_SIZE} --producer-props acks=all bootstrap.servers=${KAFKA_SERVICE_URI} --producer.config ./client.properties --print-metrics | grep ^producer- | sed 's/[[:space:]]//g')"
+        for line in ${metrics};
+        do
+            KEY="aiven.kafka."$(echo "$line" | cut -d'{' -f1 | sed 's/.$//; s/:/./;')
+            VAL=$(echo "$line" | awk -F':' {'print $NF'})
+
+            [[ $VAL == "NaN" ]] && VAL="0"
+
+            echo "$KEY--$VAL"
+            ../scripts/dd-custom-metric.sh $KEY $VAL &
+        done
+        sleep ${SLEEP}
+    done
+}
+
+perfbeat_consumer() {
+    perfbeat_init
+
+    while [ 1 ];
+    do
+        metrics="$(${KAFKA_HOME}/bin/kafka-consumer-perf-test.sh --topic ${TOPIC} --messages ${MAX_RECORDS} --consumer.config ./client.properties --bootstrap-server=${KAFKA_SERVICE_URI} --print-metrics --show-detailed-stats | grep ^consumer- | sed 's/[[:space:]]//g')"
+        for line in ${metrics};
+        do
+
+            KEY="aiven.kafka."$(echo "$line" | cut -d'{' -f1 | sed 's/.$//; s/:/./;')
+            VAL=$(echo "$line" | awk -F':' {'print $NF'})
+
+            [[ $VAL == "NaN" ]] && VAL="0"
+
+            echo "$KEY--$VAL"
+            ../scripts/dd-custom-metric.sh $KEY $VAL &
+        done
+        sleep ${SLEEP}
+    done
+}
+
+case $1 in
+    producer)
+        perfbeat_producer ;;
+    consumer)
+        perfbeat_consumer ;;
+   *)
+       printf "Usage: ./kafka-perfbeat.sh [producer|consumer]\n" ;;
+esac


### PR DESCRIPTION
This script uses kafka-producer-perf-test.sh and kafka-consumer-perf-test.sh from Apache Kafka distribution to send producer and consumer metrics to Datadog. 