### PR TITLE
Spoke Hub Schema Replication

### DIFF
--- a/solutions/diskless-spokes-hub/service-integrations-data-replication/main.tf
+++ b/solutions/diskless-spokes-hub/service-integrations-data-replication/main.tf
@@ -1,34 +1,57 @@
 # // DATA REPLICATION : MM2 spoke service integration for Data Replication
 resource "aiven_service_integration" "mm2-spoke-svc-integration-data-source-1" {
-project                  = var.aiven_project_name
-integration_type         = "kafka_mirrormaker"
-source_service_name      = aiven_kafka.spoke_kafka_1.service_name
-destination_service_name = aiven_kafka_mirrormaker.mm2_data_replication_spoke_1.service_name
-kafka_mirrormaker_user_config {
+  project                  = var.aiven_project_name
+  integration_type         = "kafka_mirrormaker"
+  source_service_name      = aiven_kafka.spoke_kafka_1.service_name
+  destination_service_name = aiven_kafka_mirrormaker.mm2_data_replication_spoke_1.service_name
+  kafka_mirrormaker_user_config {
     cluster_alias = "aiven-spoke-data-source-cluster-1" //could use name suffix with region name 
     kafka_mirrormaker {
-        producer_max_request_size = 66901452 // default
-        producer_buffer_memory = 33554432 // default, required size is that producer batch fits to buffer memory.
-        producer_batch_size = 12000 
-        producer_linger_ms = 100
+      producer_max_request_size = 66901452 // default
+      producer_buffer_memory    = 33554432 // default, required size is that producer batch fits to buffer memory.
+      producer_batch_size       = 12000
+      producer_linger_ms        = 100
     }
-    }
+  }
 }
 
 # // DATA REPLICATION : MM2 Hub service integration for Data Replication
 resource "aiven_service_integration" "mm2-hub-svc-integration-data-destination" {
-project                  = var.aiven_project_name
-integration_type         = "kafka_mirrormaker"
-source_endpoint_id       = var.external_source_aiven_kafka_endpoint_id_euw1
-destination_service_name = aiven_kafka_mirrormaker.mm2_data_replication_spoke_1.service_name
-kafka_mirrormaker_user_config {
+  project                  = var.aiven_project_name
+  integration_type         = "kafka_mirrormaker"
+  source_endpoint_id       = var.external_source_aiven_kafka_endpoint_id_euw1
+  destination_service_name = aiven_kafka_mirrormaker.mm2_data_replication_spoke_1.service_name
+  kafka_mirrormaker_user_config {
     cluster_alias = "aiven-hub-data-destination-cluster" // could suffix with region name
     kafka_mirrormaker {
-        producer_max_request_size = 66901452 // default
-        producer_buffer_memory = 33554432 // default, required size is that producer batch fits to buffer memory.
-        producer_batch_size = 12000
-        producer_linger_ms = 100
+      producer_max_request_size = 66901452 // default
+      producer_buffer_memory    = 33554432 // default, required size is that producer batch fits to buffer memory.
+      producer_batch_size       = 12000
+      producer_linger_ms        = 100
     }
-    }
+  }
 }
 
+# // DATA REPLICATION : spoke -> hub replication flow
+resource "aiven_mirrormaker_replication_flow" "spoke_to_hub_data" {
+  depends_on = [
+    aiven_service_integration.mm2-spoke-svc-integration-data-source-1,
+    aiven_service_integration.mm2-hub-svc-integration-data-destination
+  ]
+
+  project                             = var.aiven_project_name
+  service_name                        = aiven_kafka_mirrormaker.mm2_data_replication_spoke_1.service_name
+  source_cluster                      = "aiven-spoke-data-source-cluster-1"
+  target_cluster                      = "aiven-hub-data-destination-cluster"
+  replication_policy_class            = "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
+  exactly_once_delivery_enabled       = var.data_replication_exactly_once_delivery_enabled
+  sync_group_offsets_enabled          = true
+  sync_group_offsets_interval_seconds = 10
+  offset_syncs_topic_location         = "target"
+  emit_heartbeats_enabled             = true
+  enable                              = true
+  replication_factor                  = var.data_replication_factor
+  config_properties_exclude           = var.replication_config_properties_exclude
+  topics                              = var.data_replication_topics
+  topics_blacklist                    = var.replication_topics_blacklist
+}

--- a/solutions/diskless-spokes-hub/service-integrations-data-replication/readme.md
+++ b/solutions/diskless-spokes-hub/service-integrations-data-replication/readme.md
@@ -43,13 +43,15 @@ flowchart LR
   EP -->|"mm2-hub-svc-integration-data-destination\ncluster_alias: aiven-hub-data-destination-cluster"| MM2
 ```
 
-After both integrations exist, MM2’s internal replication pipelines can mirror **data topics** (subject to the MM2 service’s own `kafka_mirrormaker_user_config` from infra—refresh groups/topics, checkpoints, etc.) between the aliased clusters.
+After both integrations exist, `aiven_mirrormaker_replication_flow.spoke_to_hub_data` mirrors **spoke → hub** telemetry/business topics between the aliased clusters. The flow uses `IdentityReplicationPolicy` to preserve topic names, enables exactly-once delivery by default, and keeps internal / replica / Connect topics out through `replication_topics_blacklist`.
 
 ### What `main.tf` defines
 
 1. **`mm2-spoke-svc-integration-data-source-1`** — MM2 **source** is the **spoke** Aiven Kafka service (`source_service_name = aiven_kafka.spoke_kafka_1.service_name`). Producer-oriented `kafka_mirrormaker_user_config` (batch size, linger, buffer memory, max request size) matches the pattern used elsewhere in this solution for MM2 throughput tuning.
 
 2. **`mm2-hub-svc-integration-data-destination`** — MM2 **source** is the **hub** cluster reached through the **`external_kafka`** integration endpoint (`source_endpoint_id = var.external_source_aiven_kafka_endpoint_id_euw1`). The resource name says “destination” in the sense of **hub-as-destination in the overall hub/spoke story**; in MM2 terms it is still a **source cluster attachment** to the MM2 service (another `cluster_alias`).
+
+3. **`spoke_to_hub_data`** — MM2 replication flow from `aiven-spoke-data-source-cluster-1` to `aiven-hub-data-destination-cluster`. Configure `data_replication_topics` with the telemetry/CDIP business topic regexes you want to land in the hub.
 
 Official reference: [aiven_service_integration](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration).
 
@@ -72,6 +74,10 @@ Same as [`../infra-setup/readme.md`](../infra-setup/readme.md#provider-requireme
 | `aiven_project_name` | yes | Aiven project for all integrations |
 | `external_source_aiven_kafka_endpoint_id_euw1` | yes | Endpoint ID for the **hub**-side MM2 source on `mm2-hub-svc-integration-data-destination` |
 | `external_source_aiven_kafka_endpoint_id_use1` | no | Optional; same naming as schema-replication. Defaults to `null` and is **not used** by current `main.tf` |
+| `data_replication_topics` | no | Java regex list for spoke → hub data topics; defaults to `telemetry\..*` and `cdip\..*` |
+| `replication_topics_blacklist` | no | Java regex list for topics excluded from replication; defaults to internal, replica, `__*`, and Connect topics |
+| `data_replication_exactly_once_delivery_enabled` | no | Enables exactly-once delivery on the data flow; defaults to `true` |
+| `data_replication_factor` | no | Replication factor for MM2 internal topics used by the flow; defaults to `3` |
 
 ## Example tfvars
 

--- a/solutions/diskless-spokes-hub/service-integrations-data-replication/readme.md
+++ b/solutions/diskless-spokes-hub/service-integrations-data-replication/readme.md
@@ -43,7 +43,7 @@ flowchart LR
   EP -->|"mm2-hub-svc-integration-data-destination\ncluster_alias: aiven-hub-data-destination-cluster"| MM2
 ```
 
-After both integrations exist, `aiven_mirrormaker_replication_flow.spoke_to_hub_data` mirrors **spoke → hub** telemetry/business topics between the aliased clusters. The flow uses `IdentityReplicationPolicy` to preserve topic names, enables exactly-once delivery by default, and keeps internal / replica / Connect topics out through `replication_topics_blacklist`.
+After both integrations exist, `aiven_mirrormaker_replication_flow.spoke_to_hub_data` mirrors **spoke → hub** data topics between the aliased clusters. The `data_replication_topics` variable controls which topic regexes are included. The flow uses `IdentityReplicationPolicy` to preserve topic names, enables exactly-once delivery by default, and keeps internal / replica / Connect topics out through `replication_topics_blacklist`.
 
 ### What `main.tf` defines
 
@@ -51,7 +51,7 @@ After both integrations exist, `aiven_mirrormaker_replication_flow.spoke_to_hub_
 
 2. **`mm2-hub-svc-integration-data-destination`** — MM2 **source** is the **hub** cluster reached through the **`external_kafka`** integration endpoint (`source_endpoint_id = var.external_source_aiven_kafka_endpoint_id_euw1`). The resource name says “destination” in the sense of **hub-as-destination in the overall hub/spoke story**; in MM2 terms it is still a **source cluster attachment** to the MM2 service (another `cluster_alias`).
 
-3. **`spoke_to_hub_data`** — MM2 replication flow from `aiven-spoke-data-source-cluster-1` to `aiven-hub-data-destination-cluster`. Configure `data_replication_topics` with the telemetry/CDIP business topic regexes you want to land in the hub.
+3. **`spoke_to_hub_data`** — MM2 replication flow from `aiven-spoke-data-source-cluster-1` to `aiven-hub-data-destination-cluster`. Configure `data_replication_topics` with the business topic regexes you want to land in the hub.
 
 Official reference: [aiven_service_integration](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration).
 
@@ -74,14 +74,14 @@ Same as [`../infra-setup/readme.md`](../infra-setup/readme.md#provider-requireme
 | `aiven_project_name` | yes | Aiven project for all integrations |
 | `external_source_aiven_kafka_endpoint_id_euw1` | yes | Endpoint ID for the **hub**-side MM2 source on `mm2-hub-svc-integration-data-destination` |
 | `external_source_aiven_kafka_endpoint_id_use1` | no | Optional; same naming as schema-replication. Defaults to `null` and is **not used** by current `main.tf` |
-| `data_replication_topics` | no | Java regex list for spoke → hub data topics; defaults to `telemetry\..*` and `cdip\..*` |
+| `data_replication_topics` | yes | Java regex list for spoke → hub data topics; replace the placeholders in `variables-example.tfvars.examples` with the business topic patterns you want to replicate |
 | `replication_topics_blacklist` | no | Java regex list for topics excluded from replication; defaults to internal, replica, `__*`, and Connect topics |
 | `data_replication_exactly_once_delivery_enabled` | no | Enables exactly-once delivery on the data flow; defaults to `true` |
 | `data_replication_factor` | no | Replication factor for MM2 internal topics used by the flow; defaults to `3` |
 
 ## Example tfvars
 
-Copy [`variables-example.tfvars.examples`](variables-example.tfvars.examples) to a local `*.tfvars` file, fill in values, and **do not commit** secrets.
+Copy [`variables-example.tfvars.examples`](variables-example.tfvars.examples) to a local `*.tfvars` file, replace the `data_replication_topics` placeholders with Java regexes for your business topics, fill in the remaining values, and **do not commit** secrets.
 
 ## Usage
 

--- a/solutions/diskless-spokes-hub/service-integrations-data-replication/variables-example.tfvars.examples
+++ b/solutions/diskless-spokes-hub/service-integrations-data-replication/variables-example.tfvars.examples
@@ -2,3 +2,17 @@ aiven_api_token                                = "<Aiven API Token>"
 aiven_project_name                             = "<Aiven Project Name>"
 external_source_aiven_kafka_endpoint_id_euw1 = "<project-name/external-kafka-endpoint-uuid-for-hub>"
 # external_source_aiven_kafka_endpoint_id_use1 = "<optional; not used by current main.tf>"
+
+data_replication_topics = [
+  "telemetry\\..*",
+  "cdip\\..*"
+]
+
+replication_topics_blacklist = [
+  ".*[\\-\\.]internal",
+  ".*\\.replica",
+  "__.*",
+  "connect.*"
+]
+
+data_replication_exactly_once_delivery_enabled = true

--- a/solutions/diskless-spokes-hub/service-integrations-data-replication/variables-example.tfvars.examples
+++ b/solutions/diskless-spokes-hub/service-integrations-data-replication/variables-example.tfvars.examples
@@ -4,8 +4,8 @@ external_source_aiven_kafka_endpoint_id_euw1 = "<project-name/external-kafka-end
 # external_source_aiven_kafka_endpoint_id_use1 = "<optional; not used by current main.tf>"
 
 data_replication_topics = [
-  "telemetry\\..*",
-  "cdip\\..*"
+  "<business-topic-regex-1>",
+  "<business-topic-regex-2>"
 ]
 
 replication_topics_blacklist = [

--- a/solutions/diskless-spokes-hub/service-integrations-data-replication/variables.tf
+++ b/solutions/diskless-spokes-hub/service-integrations-data-replication/variables.tf
@@ -20,3 +20,33 @@ variable "external_source_aiven_kafka_endpoint_id_use1" {
   default     = null
   nullable    = true
 }
+
+variable "data_replication_topics" {
+  description = "Java regular expressions for telemetry/business data topics to replicate from spoke to hub. Keep this list narrow to avoid mirroring internal or non-telemetry topics."
+  type        = list(string)
+  default     = ["telemetry\\..*", "cdip\\..*"]
+}
+
+variable "replication_topics_blacklist" {
+  description = "Java regular expressions for topics excluded from MM2 replication flows."
+  type        = list(string)
+  default     = [".*[\\-\\.]internal", ".*\\.replica", "__.*", "connect.*"]
+}
+
+variable "replication_config_properties_exclude" {
+  description = "Topic configuration properties and regular expressions that MM2 should not replicate."
+  type        = list(string)
+  default     = ["follower\\.replication\\.throttled\\.replicas", "leader\\.replication\\.throttled\\.replicas", "message\\.timestamp\\.difference\\.max\\.ms", "message\\.timestamp\\.type"]
+}
+
+variable "data_replication_exactly_once_delivery_enabled" {
+  description = "Enable exactly-once delivery for the spoke-to-hub data replication flow."
+  type        = bool
+  default     = true
+}
+
+variable "data_replication_factor" {
+  description = "Replication factor used for MM2 internal topics created for the data replication flow."
+  type        = number
+  default     = 3
+}

--- a/solutions/diskless-spokes-hub/service-integrations-data-replication/variables.tf
+++ b/solutions/diskless-spokes-hub/service-integrations-data-replication/variables.tf
@@ -22,9 +22,8 @@ variable "external_source_aiven_kafka_endpoint_id_use1" {
 }
 
 variable "data_replication_topics" {
-  description = "Java regular expressions for telemetry/business data topics to replicate from spoke to hub. Keep this list narrow to avoid mirroring internal or non-telemetry topics."
+  description = "Java regular expressions for business data topics to replicate from spoke to hub. Keep this list narrow to avoid mirroring unrelated topics."
   type        = list(string)
-  default     = ["telemetry\\..*", "cdip\\..*"]
 }
 
 variable "replication_topics_blacklist" {

--- a/solutions/diskless-spokes-hub/service-integrations-schema-replication/main.tf
+++ b/solutions/diskless-spokes-hub/service-integrations-schema-replication/main.tf
@@ -1,33 +1,57 @@
 # // MM2 Hub service integration for Schema Replication --- This is local within the same VPC and hence it uses kafka service name
 resource "aiven_service_integration" "mm2-hub-svc-integration-schema-source" {
-project                  = var.aiven_project_name
-integration_type         = "kafka_mirrormaker"
-source_service_name      = aiven_kafka.hub_kafka.service_name
-destination_service_name = aiven_kafka_mirrormaker.mm2_schema_replication_1.service_name
-kafka_mirrormaker_user_config {
+  project                  = var.aiven_project_name
+  integration_type         = "kafka_mirrormaker"
+  source_service_name      = aiven_kafka.hub_kafka.service_name
+  destination_service_name = aiven_kafka_mirrormaker.mm2_schema_replication_1.service_name
+  kafka_mirrormaker_user_config {
     cluster_alias = "aiven-hub-schema-produce-cluster"
     kafka_mirrormaker {
-        producer_max_request_size = 66901452 // default
-        producer_buffer_memory = 33554432 // default, required size is that producer batch fits to buffer memory.
-        producer_batch_size = 12000
-        producer_linger_ms = 100
+      producer_max_request_size = 66901452 // default
+      producer_buffer_memory    = 33554432 // default, required size is that producer batch fits to buffer memory.
+      producer_batch_size       = 12000
+      producer_linger_ms        = 100
     }
-    }
+  }
 }
 
 # // MM2 spoke service integration for Schema Replication -- This integration has to talk over an external kafka or Aiven Kafka within a different VPC network it needs to be using service endpoint id
 resource "aiven_service_integration" "mm2-spoke-svc-integration-schema-destination" {
-project                  = var.aiven_project_name
-integration_type         = "kafka_mirrormaker"
-source_endpoint_id       = var.external_source_aiven_kafka_endpoint_id_use1
-destination_service_name = aiven_kafka_mirrormaker.mm2_schema_replication_1.service_name
-kafka_mirrormaker_user_config {
+  project                  = var.aiven_project_name
+  integration_type         = "kafka_mirrormaker"
+  source_endpoint_id       = var.external_source_aiven_kafka_endpoint_id_use1
+  destination_service_name = aiven_kafka_mirrormaker.mm2_schema_replication_1.service_name
+  kafka_mirrormaker_user_config {
     cluster_alias = "aiven-spoke-schema-receiver-cluster"
     kafka_mirrormaker {
-        producer_max_request_size = 66901452 // default
-        producer_buffer_memory = 33554432 // default, required size is that producer batch fits to buffer memory.
-        producer_batch_size = 12000 
-        producer_linger_ms = 100
+      producer_max_request_size = 66901452 // default
+      producer_buffer_memory    = 33554432 // default, required size is that producer batch fits to buffer memory.
+      producer_batch_size       = 12000
+      producer_linger_ms        = 100
     }
-    }
+  }
+}
+
+# // SCHEMA REPLICATION : hub -> spoke replication flow
+resource "aiven_mirrormaker_replication_flow" "hub_to_spoke_schema" {
+  depends_on = [
+    aiven_service_integration.mm2-hub-svc-integration-schema-source,
+    aiven_service_integration.mm2-spoke-svc-integration-schema-destination
+  ]
+
+  project                             = var.aiven_project_name
+  service_name                        = aiven_kafka_mirrormaker.mm2_schema_replication_1.service_name
+  source_cluster                      = "aiven-hub-schema-produce-cluster"
+  target_cluster                      = "aiven-spoke-schema-receiver-cluster"
+  replication_policy_class            = "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
+  exactly_once_delivery_enabled       = var.schema_replication_exactly_once_delivery_enabled
+  sync_group_offsets_enabled          = true
+  sync_group_offsets_interval_seconds = 10
+  offset_syncs_topic_location         = "target"
+  emit_heartbeats_enabled             = true
+  enable                              = true
+  replication_factor                  = var.schema_replication_factor
+  config_properties_exclude           = var.replication_config_properties_exclude
+  topics                              = var.schema_replication_topics
+  topics_blacklist                    = var.replication_topics_blacklist
 }

--- a/solutions/diskless-spokes-hub/service-integrations-schema-replication/provider.tf
+++ b/solutions/diskless-spokes-hub/service-integrations-schema-replication/provider.tf
@@ -1,11 +1,11 @@
 terraform {
   required_providers {
     aiven = {
-      source = "aiven/aiven"
+      source  = "aiven/aiven"
       version = "~> 4.0"
     }
     time = {
-      source = "hashicorp/time"
+      source  = "hashicorp/time"
       version = "0.7.2"
     }
     env = {

--- a/solutions/diskless-spokes-hub/service-integrations-schema-replication/readme.md
+++ b/solutions/diskless-spokes-hub/service-integrations-schema-replication/readme.md
@@ -16,6 +16,7 @@ This directory’s **`provider.tf`** matches **[`../infra-setup/provider.tf`](..
 
 1. **`mm2-hub-svc-integration-schema-source`** — MM2 source is the **hub Aiven Kafka service** (`source_service_name`), appropriate when MM2 and the hub are in the same connectivity context.
 2. **`mm2-spoke-svc-integration-schema-destination`** — MM2 source is the **`external_kafka` endpoint** (`source_endpoint_id` = `external_source_aiven_kafka_endpoint_id_use1`), for a spoke or external cluster reached via the registered endpoint.
+3. **`hub_to_spoke_schema`** — MM2 replication flow from `aiven-hub-schema-produce-cluster` to `aiven-spoke-schema-receiver-cluster`. It defaults to the `_schemas` topic, uses `IdentityReplicationPolicy` to preserve the topic name, enables exactly-once delivery, and excludes internal / replica / Connect topics.
 
 Official reference: [aiven_service_integration](https://registry.terraform.io/providers/aiven/aiven/latest/docs/resources/service_integration).
 
@@ -38,6 +39,10 @@ Same as [`../infra-setup/readme.md`](../infra-setup/readme.md#provider-requireme
 | `aiven_project_name` | yes | Aiven project for all integrations |
 | `external_source_aiven_kafka_endpoint_id_use1` | yes | Endpoint ID for the spoke-side MM2 source on `mm2-spoke-svc-integration-schema-destination` |
 | `external_source_aiven_kafka_endpoint_id_euw1` | no | Optional; same naming as data-replication. Defaults to `null` and is **not used** by current `main.tf` |
+| `schema_replication_topics` | no | Java regex list for hub → spoke schema topics; defaults to `_schemas` |
+| `replication_topics_blacklist` | no | Java regex list for topics excluded from replication; defaults to internal, replica, `__*`, and Connect topics |
+| `schema_replication_exactly_once_delivery_enabled` | no | Enables exactly-once delivery on the schema flow; defaults to `true` |
+| `schema_replication_factor` | no | Replication factor for MM2 internal topics used by the flow; defaults to `3` |
 
 ## Example tfvars
 

--- a/solutions/diskless-spokes-hub/service-integrations-schema-replication/variables-example.tfvars.examples
+++ b/solutions/diskless-spokes-hub/service-integrations-schema-replication/variables-example.tfvars.examples
@@ -2,3 +2,16 @@ aiven_api_token                                = "<Aiven API Token>"
 aiven_project_name                             = "<Aiven Project Name>"
 external_source_aiven_kafka_endpoint_id_use1 = "<project-name/external-kafka-endpoint-uuid>"
 # external_source_aiven_kafka_endpoint_id_euw1 = "<optional; not used by current main.tf>"
+
+schema_replication_topics = [
+  "_schemas"
+]
+
+replication_topics_blacklist = [
+  ".*[\\-\\.]internal",
+  ".*\\.replica",
+  "__.*",
+  "connect.*"
+]
+
+schema_replication_exactly_once_delivery_enabled = true

--- a/solutions/diskless-spokes-hub/service-integrations-schema-replication/variables.tf
+++ b/solutions/diskless-spokes-hub/service-integrations-schema-replication/variables.tf
@@ -20,3 +20,33 @@ variable "external_source_aiven_kafka_endpoint_id_euw1" {
   default     = null
   nullable    = true
 }
+
+variable "schema_replication_topics" {
+  description = "Java regular expressions for schema topics to replicate from hub to spoke."
+  type        = list(string)
+  default     = ["_schemas"]
+}
+
+variable "replication_topics_blacklist" {
+  description = "Java regular expressions for topics excluded from MM2 replication flows."
+  type        = list(string)
+  default     = [".*[\\-\\.]internal", ".*\\.replica", "__.*", "connect.*"]
+}
+
+variable "replication_config_properties_exclude" {
+  description = "Topic configuration properties and regular expressions that MM2 should not replicate."
+  type        = list(string)
+  default     = ["follower\\.replication\\.throttled\\.replicas", "leader\\.replication\\.throttled\\.replicas", "message\\.timestamp\\.difference\\.max\\.ms", "message\\.timestamp\\.type"]
+}
+
+variable "schema_replication_exactly_once_delivery_enabled" {
+  description = "Enable exactly-once delivery for the hub-to-spoke schema replication flow."
+  type        = bool
+  default     = true
+}
+
+variable "schema_replication_factor" {
+  description = "Replication factor used for MM2 internal topics created for the schema replication flow."
+  type        = number
+  default     = 3
+}


### PR DESCRIPTION
Data replication is spoke -> hub in service-integrations-data-replication/main.tf. 
Schema replication is hub -> spoke in service-integrations-schema-replication/main.tf. 
Both flows depend on the MM2 service integrations, so flows are created after MM2 is attached to both Kafka clusters. Both use unique cluster aliases that match the integration cluster_alias values. 
Both use IdentityReplicationPolicy, topic include filters, internal-topic blacklists, and exactly-once delivery enabled by default. 
No new Kafka/MM2 infrastructure is added, only aiven_mirrormaker_replication_flow config resources against the existing services.


